### PR TITLE
Torchscript for SphericalExpansion

### DIFF
--- a/tests/test_torchscript.py
+++ b/tests/test_torchscript.py
@@ -1,0 +1,28 @@
+import json
+import pytest
+
+import torch
+
+import equistore
+import numpy as np
+import ase.io
+
+from torch_spex.spherical_expansions import VectorExpansion, SphericalExpansion
+from torch_spex.structures import Structures
+
+#from torch_spex.spliner import Structures
+
+class TestTorchScript:
+    device = "cpu"
+    frames = ase.io.read('datasets/rmd17/ethanol1.extxyz', ':1')
+    all_species = np.unique(np.hstack([frame.numbers for frame in frames]))
+    structures = Structures(frames)
+    with open("tests/data/expansion_coeffs-ethanol1_0-hypers.json", "r") as f:
+        hypers = json.load(f)
+
+    def test_vector_expansion_coeffs(self):
+        torch.manual_seed(0)
+        spherical_expansion_calculator = SphericalExpansion(self.hypers, self.all_species)
+        spherical_expansion_calculator.forward(self.structures)
+        script_module = torch.jit.trace(spherical_expansion_calculator, (self.structures,))
+        torch.jit.script(script_module)

--- a/torch_spex/radial_basis.py
+++ b/torch_spex/radial_basis.py
@@ -9,12 +9,10 @@ class RadialBasis(torch.nn.Module):
 
         self.n_max_l, self.spliner = get_le_spliner(hypers["E_max"], hypers["r_cut"], device=device)
         self.l_max = len(self.n_max_l) - 1
-        self.radial_transform = (lambda x: x)
 
     def forward(self, r):
 
-        x = self.radial_transform(r)
-        radial_functions = self.spliner.compute(x)
+        radial_functions = self.spliner.compute(r)
 
         radial_basis = []
         index = 0

--- a/torch_spex/spherical_expansions.py
+++ b/torch_spex/spherical_expansions.py
@@ -243,19 +243,19 @@ def get_cartesian_vectors(structures, cutoff_radius):
     labels = []
     vectors = []
 
-    for structure_index in range(structures.n_structures):
+    for structure_index in range(structures["n_structures"]):
 
-        where_selected_structure = np.where(structures.structure_indices == structure_index)[0]
+        where_selected_structure = np.where(structures["structure_indices"] == structure_index)[0]
 
         centers, neighbors, unit_cell_shift_vectors = get_neighbor_list(
-            structures.positions.detach().cpu().numpy()[where_selected_structure], 
-            structures.pbcs[structure_index], 
-            structures.cells[structure_index], 
+            structures["positions"].detach().cpu().numpy()[where_selected_structure], 
+            structures["pbcs"][structure_index], 
+            structures["cells"][structure_index], 
             cutoff_radius) 
         
-        positions = structures.positions[torch.LongTensor(where_selected_structure)]
-        cell = torch.tensor(np.array(structures.cells[structure_index]), dtype=torch.get_default_dtype())
-        species = structures.atomic_species[structure_index]
+        positions = structures["positions"][torch.LongTensor(where_selected_structure)]
+        cell = torch.tensor(np.array(structures["cells"][structure_index]), dtype=torch.get_default_dtype())
+        species = structures["atomic_species"][structure_index]
 
         structure_vectors = positions[neighbors] - positions[centers] + (unit_cell_shift_vectors @ cell).to(positions.device)  # Warning: it works but in a weird way when there is no cell
         vectors.append(structure_vectors)

--- a/torch_spex/structures.py
+++ b/torch_spex/structures.py
@@ -1,37 +1,38 @@
 import numpy as np
 import torch
+from typing import List
+import ase
 
 
-class Structures:
+# Structures = Dict[torch.Tensor]
 
-    # This class essentially takes a list of Atoms objects and converts
-    # all the relevant data into torch data structures
+def Structures(atoms_list : List[ase.Atoms]):
+    structure = {}
+    structure["n_structures"] = torch.tensor(len(atoms_list))
 
-    def __init__(self, atoms_list) -> None:
-        
-        self.n_structures = len(atoms_list)
+    positions = []
+    cells = []
+    structure_indices = []
+    atomic_species = []
+    pbcs = []
 
-        positions = []
-        cells = []
-        structure_indices = []
-        atomic_species = []
-        pbcs = []
+    for structure_index, atoms in enumerate(atoms_list):
+        positions.append(atoms.positions)
+        cells.append(atoms.cell)
+        for _ in range(atoms.positions.shape[0]):
+            structure_indices.append(structure_index)
+        atomic_species.append(atoms.get_atomic_numbers())
+        pbcs.append(atoms.pbc)
 
-        for structure_index, atoms in enumerate(atoms_list):
-            positions.append(atoms.positions)
-            cells.append(atoms.cell)
-            for _ in range(atoms.positions.shape[0]):
-                structure_indices.append(structure_index)
-            atomic_species.append(atoms.get_atomic_numbers())
-            pbcs.append(atoms.pbc)
+    structure["positions"] = torch.tensor(np.concatenate(positions, axis=0), dtype=torch.get_default_dtype())
+    structure["cells"] = torch.tensor(cells)
+    structure["structure_indices"] = torch.tensor(structure_indices)
+    structure["atomic_species"] = torch.tensor(atomic_species)
+    structure["pbcs"] = torch.tensor(pbcs)
+    return structure
 
-        self.positions = torch.tensor(np.concatenate(positions, axis=0), dtype=torch.get_default_dtype())
-        self.cells = cells
-        self.structure_indices = np.array(structure_indices)
-        self.atomic_species = atomic_species
-        self.pbcs = pbcs
-
-    def to(self, device):
-
-        self.positions = self.positions.to(device)
+# need to think about this
+#    def to(self, device):
+#
+#        self.positions = self.positions.to(device)
 


### PR DESCRIPTION
- There was some identity lambda function in `radial_basis.py` that I removed
- The spline module is not torch scriptable because it uses callables as input. This is not problematic at the moment. In the future we can think about how to restructure this in a meaningful way
- Tracing does not work because for the Structures object (see error messages below), so I made a dict out of only tensors this (in near future we could also support equistore objects).

Error message on tracing
> RuntimeError: Tracer cannot infer type of (<torch_spex.structures.Structures object at 0x7f98b064bfa0>,)
:Only tensors and (possibly nested) tuples of tensors, lists, or dictsare supported as inputs or outputs of traced functions, but instead got value of type Structures.

Second error message (everything needs to have consistent type)
> Dictionary inputs to traced functions must have consistent type. Found int and Tensor

Now I hit the equistore object in the error. We can also play around with dictionary objects of tensor for the moment, but this was just to test the water, there are couple of other PRs that need to be merged before I come back to this.