### PR TITLE
Fix various issues with the tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,5 +24,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - run:  pip install tox
 
+    # uncomment for debug purposes
+    #- name: Setup upterm session
+    #  uses: lhotari/action-upterm@v1
+
     - name: run Python tests
       run: tox -e tests

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     name='torch_spex',
     packages = find_packages(),
     install_requires=[
-        'sphericart[torch]@git+https://github.com/lab-cosmo/sphericart.git',
+        'sphericart[torch]@git+https://github.com/lab-cosmo/sphericart.git@ecf4145', # prebuild wheels don't work
         'numpy',
         'ase',
         'torch',

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'ase',
         'torch',
         'scipy',
-        'equistore@git+https://github.com/lab-cosmo/equistore.git#c022fde',
+        'equistore@git+https://github.com/lab-cosmo/equistore.git@c022fde',
     ],
     dependency_links = dependency_links
 )

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         'ase',
         'torch',
         'scipy',
-        'equistore@git+https://github.com/lab-cosmo/equistore.git@c022fde',
+        'equistore@https://github.com/lab-cosmo/equistore/archive/c022fde.zip',
     ],
     dependency_links = dependency_links
 )

--- a/tests/test_spherical_expansions.py
+++ b/tests/test_spherical_expansions.py
@@ -5,6 +5,7 @@ import pytest
 import torch
 
 import equistore
+from equistore import Labels, TensorBlock, TensorMap
 import numpy as np
 import ase.io
 
@@ -21,9 +22,12 @@ class TestSphericalExpansion:
 
     def test_vector_expansion_coeffs(self):
         tm_ref = equistore.core.io.load_custom_array("tests/data/vector_expansion_coeffs-ethanol1_0-data.npz", equistore.core.io.create_torch_array)
+        # we need to sort both computed and reference pair expansion coeffs,
+        # because ase.neighborlist can get different neighborlist order for some reasons
+        tm_ref = sort_tm(tm_ref)
         vector_expansion = VectorExpansion(self.hypers, self.all_species, device="cpu")
         with torch.no_grad():
-            tm = vector_expansion.forward(self.structures)
+            tm = sort_tm(vector_expansion.forward(self.structures))
         # Default types are float32 so we cannot get higher accuracy than 1e-7.
         # Because the reference value have been cacluated using float32 and
         # now we using float64 computation the accuracy had to be decreased again
@@ -60,3 +64,39 @@ class TestSphericalExpansion:
         # Because the reference value have been cacluated using float32 and
         # now we using float64 computation the accuracy had to be decreased again
         assert equistore.operations.allclose(tm_ref, tm, atol=1e-5, rtol=1e-5)
+
+### these util functions will be removed once lab-cosmo/equistore/pull/281 is merged
+def native_list_argsort(native_list):
+    return sorted(range(len(native_list)), key=native_list.__getitem__)
+
+def sort_tm(tm):
+    blocks = []
+    for _, block in tm.items():
+        values = block.values
+
+        samples_values = block.samples.values
+        sorted_idx = native_list_argsort([tuple(row.tolist()) for row in block.samples.values])
+        samples_values = samples_values[sorted_idx]
+        values = values[sorted_idx]
+
+        components_values = []
+        for i, component in enumerate(block.components):
+            component_values = component.values
+            sorted_idx = native_list_argsort([tuple(row.tolist()) for row in component.values])
+            components_values.append( component_values[sorted_idx] )
+            values = np.take(values, sorted_idx, axis=i+1)
+
+        properties_values = block.properties.values
+        sorted_idx = native_list_argsort([tuple(row.tolist()) for row in block.properties.values])
+        properties_values = properties_values[sorted_idx]
+        values = values[..., sorted_idx]
+
+        blocks.append(
+            TensorBlock(
+                values=values,
+                samples=Labels(values=samples_values, names=block.samples.names),
+                components=[Labels(values=components_values[i], names=component.names) for i, component in enumerate(block.components)],
+                properties=Labels(values=properties_values, names=block.properties.names)
+            )
+        )
+    return TensorMap(keys=tm.keys, blocks=blocks)

--- a/tests/test_spherical_expansions.py
+++ b/tests/test_spherical_expansions.py
@@ -24,16 +24,20 @@ class TestSphericalExpansion:
         vector_expansion = VectorExpansion(self.hypers, self.all_species, device="cpu")
         with torch.no_grad():
             tm = vector_expansion.forward(self.structures)
-        # default types are float32 so we set accuracy to 1e-7
-        equistore.operations.allclose(tm_ref, tm, atol=1e-7, rtol=1e-7)
+        # Default types are float32 so we cannot get higher accuracy than 1e-7.
+        # Because the reference value have been cacluated using float32 and
+        # now we using float64 computation the accuracy had to be decreased again
+        assert equistore.operations.allclose(tm_ref, tm, atol=1e-5, rtol=1e-5)
 
     def test_spherical_expansion_coeffs(self):
         tm_ref = equistore.core.io.load_custom_array("tests/data/spherical_expansion_coeffs-ethanol1_0-data.npz", equistore.core.io.create_torch_array)
         spherical_expansion_calculator = SphericalExpansion(self.hypers, self.all_species)
         with torch.no_grad():
             tm = spherical_expansion_calculator.forward(self.structures)
-        # default types are float32 so we set accuracy to 1e-7
-        equistore.operations.allclose(tm_ref, tm, atol=1e-7, rtol=1e-7)
+        # Default types are float32 so we cannot get higher accuracy than 1e-7.
+        # Because the reference value have been cacluated using float32 and
+        # now we using float64 computation the accuracy had to be decreased again
+        assert equistore.operations.allclose(tm_ref, tm, atol=1e-5, rtol=1e-5)
 
     def test_spherical_expansion_coeffs_alchemical(self):
         with open("tests/data/expansion_coeffs-ethanol1_0-alchemical-hypers.json", "r") as f:
@@ -41,7 +45,18 @@ class TestSphericalExpansion:
         tm_ref = equistore.core.io.load_custom_array("tests/data/spherical_expansion_coeffs-ethanol1_0-alchemical-seed0-data.npz", equistore.core.io.create_torch_array)
         torch.manual_seed(0)
         spherical_expansion_calculator = SphericalExpansion(hypers, self.all_species)
+        # Because setting seed seems not be enough to get the same initial combination matrix
+        # as in the reference values, we set the combination matrix manually
+        with torch.no_grad():
+            # wtf? suggested way by torch developers
+            # https://discuss.pytorch.org/t/initialize-nn-linear-with-specific-weights/29005/4
+            spherical_expansion_calculator.vector_expansion_calculator.radial_basis_calculator.combination_matrix.weight.copy_(torch.tensor(
+                    [[-0.00432252,  0.30971584, -0.47518533],
+                     [-0.4248946 , -0.22236897,  0.15482073]], dtype=torch.float32))
+
         with torch.no_grad():
             tm = spherical_expansion_calculator.forward(self.structures)
-        # default types are float32 so we set accuracy to 1e-7
-        equistore.operations.allclose(tm_ref, tm, atol=1e-7, rtol=1e-7)
+        # Default types are float32 so we cannot get higher accuracy than 1e-7.
+        # Because the reference value have been cacluated using float32 and
+        # now we using float64 computation the accuracy had to be decreased again
+        assert equistore.operations.allclose(tm_ref, tm, atol=1e-5, rtol=1e-5)

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,6 @@ setenv =
 deps =
     pytest
 commands =
-    pytest
+    pytest {posargs}
     # doctest
-    pytest --doctest-modules --pyargs torch_spex
+    pytest --doctest-modules --pyargs torch_spex {posargs}


### PR DESCRIPTION
We had several issues with the tests which have been resolved
- using the most recent version of sphericart is hard to debug, because each PR can have different behavior because of an update in sphericart, so I pinned the version to commit
- the version pinning of equistore was buggy so the most recent version was always used
- the asserts were missing, and by the movement of alchemical combination matrix to the radial basis setting the seed was not enough to get the same combination matrix as in the reference value. Now I just hardcoded the combination matrix in the test  